### PR TITLE
Export by name

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -1,0 +1,7 @@
+import * as SimpleDOM from './simple-dom';
+
+if(typeof window !== "undefined") {
+	window.SimpleDOM = SimpleDOM;
+}
+
+export * from './simple-dom';

--- a/lib/simple-dom.js
+++ b/lib/simple-dom.js
@@ -5,7 +5,7 @@ import HTMLParser from './simple-dom/html-parser';
 import HTMLSerializer from './simple-dom/html-serializer';
 import voidMap from './simple-dom/void-map';
 
-var SimpleDOM = {
+export {
   Node,
   Element,
   Document,
@@ -13,9 +13,3 @@ var SimpleDOM = {
   HTMLSerializer,
   voidMap
 };
-
-if(typeof window !== "undefined") {
-	window.SimpleDOM = SimpleDOM;
-}
-
-export default SimpleDOM;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "can-simple-dom",
   "version": "0.2.4",
   "description": "A simple JS DOM.",
-  "main": "dist/cjs/simple-dom.js",
+  "main": "dist/cjs/main.js",
   "scripts": {
     "build": "node build.js",
     "prepublish": "node build.js"
@@ -20,13 +20,14 @@
     "url": "https://github.com/canjs/simple-dom.git"
   },
   "system": {
-    "main": "simple-dom.js",
+    "main": "main.js",
     "npmIgnore": [
       "devDependencies"
     ],
     "directories": {
       "lib": "lib"
-    }
+    },
+    "transpiler": "babel"
   },
   "devDependencies": {
   	"steal-tools": "^0.10.4"


### PR DESCRIPTION
This makes it so that exports are done by individual name, this way you
don't have to use `.default`.
