### PR TITLE
Implement the AnchorElement

### DIFF
--- a/lib/simple-dom/document.js
+++ b/lib/simple-dom/document.js
@@ -3,6 +3,7 @@ import Element from './document/element';
 import Text from './document/text';
 import Comment from './document/comment';
 import DocumentFragment from './document/document-fragment';
+import AnchorElement from './document/anchor-element';
 
 function Document() {
   this.nodeConstructor(9, '#document', null, this);
@@ -16,7 +17,16 @@ Document.prototype = Object.create(Node.prototype);
 Document.prototype.constructor = Document;
 Document.prototype.nodeConstructor = Node;
 
+const specialElements = {
+  "a": AnchorElement
+};
+
 Document.prototype.createElement = function(tagName) {
+  var Special = specialElements[tagName.toLowerCase()];
+  if(Special) {
+    return new Special(tagName, this);
+  }
+
   return new Element(tagName, this);
 };
 

--- a/lib/simple-dom/document/anchor-element.js
+++ b/lib/simple-dom/document/anchor-element.js
@@ -1,0 +1,22 @@
+import Element from './element';
+import Location from 'micro-location';
+import extend from '../extend';
+
+function AnchorElement(tagName, ownerDocument) {
+  this.elementConstructor(tagName, ownerDocument);
+
+  extend(this, Location.parse(''));
+}
+
+AnchorElement.prototype = Object.create(Element.prototype);
+AnchorElement.prototype.constructor = AnchorElement;
+AnchorElement.prototype.elementConstructor = Element;
+
+AnchorElement.prototype.setAttribute = function(_name, value){
+  Element.prototype.setAttribute.apply(this, arguments);
+  if(_name.toLowerCase() === "href") {
+    extend(this, Location.parse(value));
+  }
+};
+
+export default AnchorElement;

--- a/lib/simple-dom/document/node.js
+++ b/lib/simple-dom/document/node.js
@@ -95,6 +95,10 @@ Node.prototype.insertBefore = function(node, refNode) {
     return node;
   }
 
+  if (node.parentNode) {
+    node.parentNode.removeChild(node);
+  }
+
   node.parentNode = this;
 
   var previousSibling = refNode.previousSibling;

--- a/lib/simple-dom/extend.js
+++ b/lib/simple-dom/extend.js
@@ -1,0 +1,6 @@
+export default function(a, b){
+  for(var p in b) {
+    a[p] = b[p];
+  }
+  return a;
+};

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "transpiler": "babel"
   },
   "devDependencies": {
-  	"steal-tools": "^0.10.4"
+    "steal-tools": "^0.10.4"
+  },
+  "dependencies": {
+    "micro-location": "^0.1.4"
   }
 }


### PR DESCRIPTION
Needed to implement the AnchorElement as extending Element.  This is
needed because can/route/pushstate uses element.pathname, so we need to
parse the href location.
