### PR TITLE
Fix reference to Location for CJS environments

### DIFF
--- a/build.js
+++ b/build.js
@@ -6,7 +6,9 @@ stealTools.export({
 	},
 	outputs: {
 		"+amd": {},
-		"+global-js": {},
+		"+global-js": {
+			exports: { "micro-location": "Location" }
+		},
 		"+cjs": {}
 	}
 }).catch(function(e){

--- a/lib/simple-dom/document/anchor-element.js
+++ b/lib/simple-dom/document/anchor-element.js
@@ -2,6 +2,9 @@ import Element from './element';
 import Location from 'micro-location';
 import extend from '../extend';
 
+// micro-location doesn't export properly for cjs - this fixes that #11
+Location = Location.Location || Location;
+
 function AnchorElement(tagName, ownerDocument) {
   this.elementConstructor(tagName, ownerDocument);
 

--- a/lib/simple-dom/document/anchor-element.js
+++ b/lib/simple-dom/document/anchor-element.js
@@ -1,9 +1,8 @@
 import Element from './element';
-import Location from 'micro-location';
+import microLocation from 'micro-location';
 import extend from '../extend';
 
-// micro-location doesn't export properly for cjs - this fixes that #11
-Location = Location.Location || Location;
+const Location = microLocation.Location;
 
 function AnchorElement(tagName, ownerDocument) {
   this.elementConstructor(tagName, ownerDocument);

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "transpiler": "babel",
     "meta": {
       "micro-location": {
-        "exports": "Location"
+        "format": "cjs"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -28,12 +28,7 @@
     "npmIgnore": [
       "testee"
     ],
-    "transpiler": "babel",
-    "meta": {
-      "micro-location": {
-        "format": "cjs"
-      }
-    }
+    "transpiler": "babel"
   },
   "devDependencies": {
     "steal": "^0.11.4",

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -122,3 +122,16 @@ QUnit.test("cloneNode(true) recursively clones nodes", function(assert) {
 
   assert.equal(actual, '<div><p>hello<span> world</span>!</p><img src="hamster.png"><span></span></div>');
 });
+
+QUnit.test("anchor element is created successfully - micro-location works (see #11)", function (assert) {
+  assert.expect(0);
+
+  var document = new Document();
+
+  try {
+    document.createElement("a");
+  } catch (ex) {
+    assert.ok(false, "Anchor throws exception");
+    console.log(ex.stack);
+  }
+});

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -132,6 +132,5 @@ QUnit.test("anchor element is created successfully - micro-location works (see #
     document.createElement("a");
   } catch (ex) {
     assert.ok(false, "Anchor throws exception");
-    console.log(ex.stack);
   }
 });


### PR DESCRIPTION
This fixes #11. This is necessary for a utility I built which uses can-simple-dom - it's also necessary for anybody using can-simple-dom in a CJS environment.
