### PR TITLE
Set the className when the attribute "class" is set

### DIFF
--- a/lib/simple-dom/document/element.js
+++ b/lib/simple-dom/document/element.js
@@ -1,6 +1,11 @@
 import Node from './node';
 
 
+let attrSpecial = {
+  "class": function(element, value){
+    element._className = value;
+  }
+};
 
 
 function Element(tagName, ownerDocument) {
@@ -61,6 +66,11 @@ Element.prototype._setAttribute = function(_name, value) {
   });
   // a map and array
   attributes[name] = value;
+
+  let special = attrSpecial[name];
+  if(special) {
+    special(this, value);
+  }
 };
 
 Element.prototype.removeAttribute = function(name) {

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -157,3 +157,11 @@ QUnit.test("replaceChild works", function(assert){
 	assert.equal(oldChild, one, 'correct return value');
 	assert.equal(parent.firstChild.nodeName, 'SPAN', 'child is now the span');
 });
+
+QUnit.test("setAttribute('class', value) updates the className", function(assert){
+	var document = new Document();
+	var el = document.createElement("div");
+	el.setAttribute("class", "foo bar");
+
+	assert.equal(el.className, "foo bar", "Element's className is same as the attribute class");
+});


### PR DESCRIPTION
This adds the ability to have special attributes with extra behavior.
"class" is one such attribute, it defines a function that also sets the
attribute's `className` value. Fixes #21
