### PR TITLE
Makes jQuery 2.2 work

### DIFF
--- a/lib/simple-dom/default-tokenize.js
+++ b/lib/simple-dom/default-tokenize.js
@@ -1,0 +1,5 @@
+import tokenize from 'simple-html-tokenizer/lib/simple-html-tokenizer/tokenize';
+
+export default function(input) {
+  return tokenize(input);
+};

--- a/lib/simple-dom/document.js
+++ b/lib/simple-dom/document.js
@@ -33,8 +33,7 @@ function Document() {
         }
         document.documentElement.appendChild(frag);
       }
-      document.__parser = self.__parser;
-      document.__serializer = self.__serializer;
+      document.__addSerializerAndParser(self.__serializer, self.__parser);
       return document;
 
     }
@@ -89,7 +88,10 @@ Document.prototype.getElementById = function(id){
   return Element.prototype.getElementById.apply(this.documentElement, arguments);
 };
 
-
+Document.prototype.__addSerializerAndParser = function(serializer, parser){
+  this.__parser = parser;
+  this.__serializer = serializer;
+}
 
 if(Object.defineProperty) {
   Object.defineProperty(Document.prototype, "currentScript", {

--- a/lib/simple-dom/document.js
+++ b/lib/simple-dom/document.js
@@ -5,12 +5,40 @@ import Comment from './document/comment';
 import DocumentFragment from './document/document-fragment';
 import AnchorElement from './document/anchor-element';
 
+
+
 function Document() {
   this.nodeConstructor(9, '#document', null, this);
   this.documentElement = new Element('html', this);
   this.body = new Element('body', this);
   this.documentElement.appendChild(this.body);
   this.appendChild(this.documentElement);
+  var self = this;
+  this.implementation = {
+    createHTMLDocument: function(content){
+      var document = new Document();
+      var frag =  self.__parser.parse(content);
+
+      var body = Element.prototype.getElementsByTagName.call(frag,"body")[0];
+      var head = Element.prototype.getElementsByTagName.call(frag,"head")[0];
+      
+      if(!body && !head) {
+        document.body.appendChild(frag);
+      } else {
+        if(body) {
+          document.documentElement.replaceChild(document.body, body);
+        }
+        if(head) {
+          document.documentElement.replaceChild(document.head, head);
+        }
+        document.documentElement.appendChild(frag);
+      }
+      document.__parser = self.__parser;
+      document.__serializer = self.__serializer;
+      return document;
+
+    }
+  };
 }
 
 Document.prototype = Object.create(Node.prototype);
@@ -60,6 +88,8 @@ Document.prototype.getElementsByTagName = function(name){
 Document.prototype.getElementById = function(id){
   return Element.prototype.getElementById.apply(this.documentElement, arguments);
 };
+
+
 
 if(Object.defineProperty) {
   Object.defineProperty(Document.prototype, "currentScript", {

--- a/lib/simple-dom/document.js
+++ b/lib/simple-dom/document.js
@@ -26,10 +26,10 @@ function Document() {
         document.body.appendChild(frag);
       } else {
         if(body) {
-          document.documentElement.replaceChild(document.body, body);
+          document.documentElement.replaceChild(body, document.body);
         }
         if(head) {
-          document.documentElement.replaceChild(document.head, head);
+          document.documentElement.replaceChild(head, document.head);
         }
         document.documentElement.appendChild(frag);
       }

--- a/lib/simple-dom/document/element.js
+++ b/lib/simple-dom/document/element.js
@@ -152,22 +152,33 @@ if(Object.defineProperty) {
 			this.__node._setAttribute("style", val);
 		}
 	});
-  Object.defineProperty(Element.prototype,"innerHTML", {
-    get: function(){
-      var html = "";
-      var cur = node.firstChild;
-      while(cur) {
-        html += this.ownerDocument.__serializer.serialize(cur);
-        cur = cur.nextSibling;
-      }
-      return html;
-    },
-    set: function(html){
-      this.lastChild = this.firstChild = null;
-      var fragment = this.ownerDocument.__parser.parse(html);
-      this.appendChild(fragment);
-    }
-  })
+  
+	Object.defineProperty(Element.prototype, "innerHTML", {
+		get: function() {
+			var html = "";
+			var cur = this.firstChild;
+			while (cur) {
+				html += this.ownerDocument.__serializer.serialize(cur);
+				cur = cur.nextSibling;
+			}
+			return html;
+		},
+		set: function(html) {
+			this.lastChild = this.firstChild = null;
+			var fragment = this.ownerDocument.__parser.parse(html);
+			this.appendChild(fragment);
+		}
+	}); 
+	
+	Object.defineProperty(Element.prototype, "outerHTML", {
+		get: function() {
+			return this.ownerDocument.__serializer.serialize(this);
+		},
+		set: function(html) {
+			this.parentNode.replaceChild(this.ownerDocument.__parser.parse(html), this);
+		}
+	}); 
+
 }
 
 

--- a/lib/simple-dom/document/element.js
+++ b/lib/simple-dom/document/element.js
@@ -152,6 +152,22 @@ if(Object.defineProperty) {
 			this.__node._setAttribute("style", val);
 		}
 	});
+  Object.defineProperty(Element.prototype,"innerHTML", {
+    get: function(){
+      var html = "";
+      var cur = node.firstChild;
+      while(cur) {
+        html += this.ownerDocument.__serializer.serialize(cur);
+        cur = cur.nextSibling;
+      }
+      return html;
+    },
+    set: function(html){
+      this.lastChild = this.firstChild = null;
+      var fragment = this.ownerDocument.__parser.parse(html);
+      this.appendChild(fragment);
+    }
+  })
 }
 
 

--- a/lib/simple-dom/dom.js
+++ b/lib/simple-dom/dom.js
@@ -5,11 +5,19 @@ import HTMLParser from './html-parser';
 import HTMLSerializer from './html-serializer';
 import voidMap from './void-map';
 
+function createDocument (serializer, parser){
+  var doc = new Document();
+  doc.__serializer = serializer;
+  doc.__parser = parser;
+  return doc;
+}
+
 export {
   Node,
   Element,
   Document,
   HTMLParser,
   HTMLSerializer,
-  voidMap
+  voidMap,
+  createDocument
 };

--- a/lib/simple-dom/html-parser.js
+++ b/lib/simple-dom/html-parser.js
@@ -18,7 +18,7 @@ HTMLParser.prototype.pushElement = function(token) {
     el.setAttribute(attr[0], attr[1]);
   }
 
-  if (this.isVoid(el)) {
+  if (this.isVoid(el) || token.selfClosing) {
     return this.appendChild(el);
   }
 

--- a/lib/simple-dom/html-parser.js
+++ b/lib/simple-dom/html-parser.js
@@ -1,4 +1,5 @@
 function HTMLParser(tokenize, document, voidMap) {
+  console.log("creating parser", typeof document);
   this.tokenize = tokenize;
   this.document = document;
   this.voidMap = voidMap;

--- a/lib/simple-dom/html-parser.js
+++ b/lib/simple-dom/html-parser.js
@@ -1,5 +1,4 @@
 function HTMLParser(tokenize, document, voidMap) {
-  console.log("creating parser", typeof document);
   this.tokenize = tokenize;
   this.document = document;
   this.voidMap = voidMap;

--- a/lib/simple-dom/html-serializer.js
+++ b/lib/simple-dom/html-serializer.js
@@ -70,6 +70,7 @@ HTMLSerializer.prototype.comment = function(comment) {
   return '<!--'+comment.nodeValue+'-->';
 };
 
+
 HTMLSerializer.prototype.serialize = function(node) {
   var buffer = '';
   var next;
@@ -90,19 +91,17 @@ HTMLSerializer.prototype.serialize = function(node) {
   }
 
   next = node.firstChild;
-  if (next) {
-    buffer += this.serialize(next);
-  } else if(node.textContent) {
-    buffer += node.textContent;
+  if(next) {
+  	while(next) {
+  	  buffer += this.serialize(next);
+  	  next = next.nextSibling;
+  	}
+  } else if(node.nodeType === 1 && node.textContent){
+  	buffer += node.textContent;
   }
 
   if (node.nodeType === 1 && !this.isVoid(node)) {
     buffer += this.closeTag(node);
-  }
-
-  next = node.nextSibling;
-  if (next) {
-    buffer += this.serialize(next);
   }
 
   return buffer;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-simple-dom",
-  "version": "0.3.0-pre.1",
+  "version": "0.3.0-pre.2",
   "description": "A simple JS DOM.",
   "main": "dist/cjs/simple-dom.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-simple-dom",
-  "version": "0.3.0-pre.0",
+  "version": "0.3.0-pre.1",
   "description": "A simple JS DOM.",
   "main": "dist/cjs/simple-dom.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -34,9 +34,11 @@
     "steal": "^0.11.4",
     "steal-qunit": "^0.1.0",
     "steal-tools": "^0.11.2",
-    "testee": "^0.2.0"
+    "testee": "^0.2.0",
+    "jquery": "^2.2.0"
   },
   "dependencies": {
-    "micro-location": "^0.1.4"
+    "micro-location": "^0.1.4",
+    "simple-html-tokenizer": "^0.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-simple-dom",
-  "version": "0.2.23",
+  "version": "0.3.0-pre.0",
   "description": "A simple JS DOM.",
   "main": "dist/cjs/simple-dom.js",
   "scripts": {
@@ -18,7 +18,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/canjs/simple-dom.git"
+    "url": "https://github.com/canjs/can-simple-dom.git"
   },
   "system": {
     "main": "simple-dom.js",

--- a/test/element-sp-test.js
+++ b/test/element-sp-test.js
@@ -20,4 +20,31 @@ QUnit.test("document.implementation is supported (#23)", function(){
   ok(doc2.body, "has a body");
 });
 
+QUnit.test("innerHTML supported", function(){
+  
+  var document = new Document();
+  document.__addSerializerAndParser(new Serializer(voidMap), new Parser(tokenize, document, voidMap));
 
+  document.body.innerHTML = "<span class='bar'>HI</span>";
+  
+  QUnit.equal( document.body.firstChild.nodeName, "SPAN");
+  QUnit.equal( document.body.firstChild.className, "bar");
+  QUnit.equal( document.body.firstChild.firstChild.nodeValue, "HI");
+  
+  QUnit.equal( document.body.innerHTML, "<span class=\"bar\">HI</span>");
+});
+
+QUnit.test("outerHTML supported", function(){
+  
+  var document = new Document();
+  document.__addSerializerAndParser(new Serializer(voidMap), new Parser(tokenize, document, voidMap));
+ 
+  document.body.innerHTML = "<span/><div id='item'>HI</div><span/>";
+  
+  var item = document.getElementById('item');
+  
+  QUnit.equal( item.outerHTML, "<div id=\"item\">HI</div>", "getter");
+  item.outerHTML = "<label>IT</label>";
+  
+  QUnit.equal( document.body.innerHTML,  "<span></span><label>IT</label><span></span>", "setter");
+});

--- a/test/element-sp-test.js
+++ b/test/element-sp-test.js
@@ -1,0 +1,24 @@
+import {Document} from 'can-simple-dom';
+import QUnit from 'steal-qunit';
+
+
+import Parser from 'can-simple-dom/simple-dom/html-parser';
+import voidMap from 'can-simple-dom/simple-dom/void-map';
+import Serializer from 'can-simple-dom/simple-dom/html-serializer';
+
+import tokenize from 'can-simple-dom/simple-dom/default-tokenize';
+
+QUnit.module('Element with serialization and parsing');
+
+QUnit.test("document.implementation is supported (#23)", function(){
+  
+  var document = new Document();
+  document.__serializer = new Serializer(voidMap), 
+  document.__parser = new Parser(tokenize, document, voidMap);
+
+  ok(document.implementation, "implementation exists");
+  var doc2 = document.implementation.createHTMLDocument("");
+  ok(doc2.body, "has a body");
+});
+
+

--- a/test/element-sp-test.js
+++ b/test/element-sp-test.js
@@ -13,8 +13,7 @@ QUnit.module('Element with serialization and parsing');
 QUnit.test("document.implementation is supported (#23)", function(){
   
   var document = new Document();
-  document.__serializer = new Serializer(voidMap), 
-  document.__parser = new Parser(tokenize, document, voidMap);
+  document.__addSerializerAndParser(new Serializer(voidMap), new Parser(tokenize, document, voidMap));
 
   ok(document.implementation, "implementation exists");
   var doc2 = document.implementation.createHTMLDocument("");

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -165,3 +165,6 @@ QUnit.test("setAttribute('class', value) updates the className", function(assert
 
 	assert.equal(el.className, "foo bar", "Element's className is same as the attribute class");
 });
+
+
+

--- a/test/jquery_test.js
+++ b/test/jquery_test.js
@@ -20,23 +20,23 @@ steal.import('can-simple-dom').then(function(simpleDOMMod){
 		var document = global.document = new simpleDOMMod.Document();
 		document.__addSerializerAndParser(
 			new simpleDOMMod.HTMLSerializer(simpleDOMMod.voidMap),
-			new simpleDOMMod.HTMLParser(tokenizeMod.default, document, simpleDOMMod.voidMap)
+			new simpleDOMMod.HTMLParser(tokenizeMod["default"], document, simpleDOMMod.voidMap)
 		);
 
 		global.location = {};
 
 		console.log("importing jQuery");
-		return steal.import('jquery')
+		return steal.import('jquery');
 
 
 	});
 	
 }).then(function(){
-	console.log("worked")
+	console.log("worked");
 }, function(e){
 	console.log("fail",e);
 
 	setTimeout(function(){
 		throw e;
-	},1)
-})
+	},1);
+});

--- a/test/jquery_test.js
+++ b/test/jquery_test.js
@@ -18,8 +18,10 @@ steal.import('can-simple-dom').then(function(simpleDOMMod){
 	return steal.import('can-simple-dom/simple-dom/default-tokenize').then(function(tokenizeMod){
 
 		var document = global.document = new simpleDOMMod.Document();
-		document.__serializer = new simpleDOMMod.HTMLSerializer(simpleDOMMod.voidMap), 
-    	document.__parser = new simpleDOMMod.HTMLParser(tokenizeMod.default, document, simpleDOMMod.voidMap);
+		document.__addSerializerAndParser(
+			new simpleDOMMod.HTMLSerializer(simpleDOMMod.voidMap),
+			new simpleDOMMod.HTMLParser(tokenizeMod.default, document, simpleDOMMod.voidMap)
+		);
 
 		global.location = {};
 

--- a/test/jquery_test.js
+++ b/test/jquery_test.js
@@ -1,0 +1,40 @@
+var Steal = require("steal"),
+	path = require('path');
+
+
+var steal =  Steal.clone();
+
+var System = global.System = steal.System;
+
+System.config({
+	config: path.join(__dirname, "..","package.json!npm"),
+	main: "@empty",
+	env: "server-development"
+});
+
+
+steal.import('can-simple-dom').then(function(simpleDOMMod){
+
+	return steal.import('can-simple-dom/simple-dom/default-tokenize').then(function(tokenizeMod){
+
+		var document = global.document = new simpleDOMMod.Document();
+		document.__serializer = new simpleDOMMod.HTMLSerializer(simpleDOMMod.voidMap), 
+    	document.__parser = new simpleDOMMod.HTMLParser(tokenizeMod.default, document, simpleDOMMod.voidMap);
+
+		global.location = {};
+
+		console.log("importing jQuery");
+		return steal.import('jquery')
+
+
+	});
+	
+}).then(function(){
+	console.log("worked")
+}, function(e){
+	console.log("fail",e);
+
+	setTimeout(function(){
+		throw e;
+	},1)
+})

--- a/test/test.js
+++ b/test/test.js
@@ -1,2 +1,3 @@
 import './element-test';
 import './serializer-test';
+import './element-sp-test';


### PR DESCRIPTION
## Adds __addSerializerAndParser

Passing this method a serializer and a parser enables `innerHTML` to work. But more importantly for jQuery 2.2, it adds support for `document.implementation.createHTMLDocument`.  This can be setup like:

```
var document = global.document = new SimpleDOM.Document();
document.__addSerializerAndParser(
  new SimpleDOM.HTMLSerializer(SimpleDOM.voidMap),
  new SimpleDOM.HTMLParser(TOKENIZE, document, SimpleDOM.voidMap)
);
```

Notice the TOKENIZE function.  This is currently tested with [simple-html-tokenizer](https://github.com/tildeio/simple-html-tokenizer/blob/master/lib/simple-html-tokenizer/tokenize.js), but can-ssr should set this up to use `can/view/parser` like [vdom/build_fragment/make_parser](https://github.com/canjs/canjs/blob/master/util/vdom/build_fragment/make_parser.js#L4) does.
## Further changes

CanJS's vdom tests and can-ssr should update themselves to make their documents like the above.

(which can be made from code already loaded by can-simple-dom) and 
