### PR TITLE
Update innerHTML to not parse content for script and style nodes

### DIFF
--- a/lib/simple-dom/document/element.js
+++ b/lib/simple-dom/document/element.js
@@ -165,7 +165,12 @@ if(Object.defineProperty) {
 		},
 		set: function(html) {
 			this.lastChild = this.firstChild = null;
-			var fragment = this.ownerDocument.__parser.parse(html);
+			var fragment;
+			if (this.nodeName === "SCRIPT" || this.nodeName === "STYLE") {
+				fragment = this.ownerDocument.createTextNode(html);
+			} else {
+				fragment = this.ownerDocument.__parser.parse(html);
+			}
 			this.appendChild(fragment);
 		}
 	}); 

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -166,5 +166,25 @@ QUnit.test("setAttribute('class', value) updates the className", function(assert
 	assert.equal(el.className, "foo bar", "Element's className is same as the attribute class");
 });
 
+QUnit.test("innerHTML does not parse the contents of SCRIPT and STYLE nodes", function (assert) {
+  var document = new Document();
+  var div = document.createElement("div");
+  var script = document.createElement("script");
 
+  try {
+    div.innerHTML = "<span>foo</span>";
+    ok(0, "should not make it here b/c no parser is shipped");
+  } catch (ex) {
+    ok(1, "tried to parse content");
+  }
 
+  var jsCode = "var foo = '<span>bar</span>';";
+  try {
+    script.innerHTML = jsCode;
+    equal(script.firstChild, script.lastChild, "script has one child");
+    equal(script.firstChild.nodeType, 3, "only child is a text node");
+    equal(script.firstChild.nodeValue, jsCode, "code matches");
+  } catch (ex) {
+    ok(0, "should not cause an error")
+  }
+});


### PR DESCRIPTION
This is a fix which previously existed when innerHTML was implemented in canjs vdom. Fixes issue #26 
