### PR TITLE
Implement textContent

### DIFF
--- a/lib/simple-dom/document/node.js
+++ b/lib/simple-dom/document/node.js
@@ -33,7 +33,7 @@ Node.prototype.cloneNode = function(deep) {
   return node;
 };
 
-Node.prototype.appendChild = function(node) {
+var nodeAppendChild = Node.prototype.appendChild = function(node) {
   if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
     insertFragment(node, this, this.lastChild, null);
     return node;
@@ -142,6 +142,25 @@ Node.prototype.replaceChild = function(newChild, oldChild){
 
 Node.prototype.addEventListener = function(){};
 Node.prototype.removeEventListener = function(){};
+
+if(Object.defineProperty) {
+	Object.defineProperty(Node.prototype, "textContent", {
+		get: function(){
+			var child = this.firstChild;
+			if(child) {
+				return child.nodeType === 3 ? child.nodeValue : "";
+			}
+			return "";
+		},
+		set: function(val){
+			while(this.firstChild) {
+				nodeRemoveChild.call(this, this.firstChild);
+			}
+			var tn = this.ownerDocument.createTextNode(val);
+			nodeAppendChild.call(this, tn);
+		}
+	});
+}
 
 Node.ELEMENT_NODE = 1;
 Node.ATTRIBUTE_NODE = 2;

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -188,3 +188,33 @@ QUnit.test("innerHTML does not parse the contents of SCRIPT and STYLE nodes", fu
     ok(0, "should not cause an error")
   }
 });
+
+QUnit.test("Setting an element's textContent inserts TextNode", function(assert){
+	var document = new Document();
+	var el = document.createElement("div");
+	el.textContent = "foo";
+
+	var tn = el.childNodes.item(0);
+	assert.equal(tn.nodeType, 3, "It is a TextNode");
+	assert.equal(tn.nodeValue, "foo", "With the text");
+	assert.equal(el.textContent, "foo", "Getter works");
+});
+
+QUnit.test("Setting textContent when there is already a child", function(assert){
+	var document = new Document();
+	var el = document.createElement("div");
+
+	// Add a child
+	el.appendChild(document.createElement("span"));
+
+	assert.equal(el.childNodes.item(0).nodeName, "SPAN", "starts as a span");
+
+	el.textContent = "hello world";
+
+	var tn = el.childNodes.item(0);
+	assert.equal(tn.nodeType, 3, "It is a TextNode");
+	assert.equal(tn.nodeValue, "hello world", "With the text");
+	assert.equal(el.textContent, "hello world", "Getter works");
+
+	assert.equal(el.childNodes.item(1), null, "span is gone");
+});


### PR DESCRIPTION
This implements textContent as a getter/setter. Created this while
testing in Firefox. What I saw was:
- Setting textContent creates a TextNode child.
- If there is an existing child (like a span) it will be replaced by the TextNode.

So the setter removes firstChild until the element is cleared out. And
then creates a new TextNode as the only child.

Fixes #32 
