### PR TITLE
encode html entities for char-nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,31 @@
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
 /node_modules
 /dist

--- a/lib/simple-dom/html-parser.js
+++ b/lib/simple-dom/html-parser.js
@@ -16,8 +16,8 @@ HTMLParser.prototype.pushElement = function(token) {
 
   for (var i=0;i<token.attributes.length;i++) {
     var attr = token.attributes[i];
-    // encode string if attribute is a title or alt
-    if(attr[0] === 'title' || attr[0] === 'alt') {
+
+    if(attr[0] !== 'href' && attr[0] !== 'src') {
       attr[1] = he.encode(attr[1]);
     }
     el.setAttribute(attr[0], attr[1]);

--- a/lib/simple-dom/html-parser.js
+++ b/lib/simple-dom/html-parser.js
@@ -1,3 +1,5 @@
+import he from 'he';
+
 function HTMLParser(tokenize, document, voidMap) {
   this.tokenize = tokenize;
   this.document = document;
@@ -14,6 +16,10 @@ HTMLParser.prototype.pushElement = function(token) {
 
   for (var i=0;i<token.attributes.length;i++) {
     var attr = token.attributes[i];
+    // encode string if attribute is a title or alt
+    if(attr[0] === 'title' || attr[0] === 'alt') {
+      attr[1] = he.encode(attr[1]);
+    }
     el.setAttribute(attr[0], attr[1]);
   }
 
@@ -35,7 +41,8 @@ HTMLParser.prototype.popElement = function(token) {
 };
 
 HTMLParser.prototype.appendText = function(token) {
-  var text = this.document.createTextNode(token.chars);
+  var content = he.encode(token.chars);
+  var text = this.document.createTextNode(content);
   this.appendChild(text);
 };
 

--- a/lib/simple-dom/html-serializer.js
+++ b/lib/simple-dom/html-serializer.js
@@ -1,3 +1,6 @@
+var REG_ESCAPE_ALL = /[<>&]/g;
+var REG_ESCAPE_PRESERVE_ENTITIES = /[<>]|&(?:#?[a-zA-Z0-9]+;)?/g;
+
 function HTMLSerializer(voidMap) {
   this.voidMap = voidMap;
 }
@@ -23,12 +26,14 @@ HTMLSerializer.prototype.attributes = function(namedNodeMap) {
 };
 
 HTMLSerializer.prototype.escapeAttrValue = function(attrValue) {
-  return attrValue.replace(/[&"]/g, function(match) {
+  return attrValue.replace(/"|&(?:#?[a-zA-Z0-9]+;)?/g, function(match) {
     switch(match) {
       case '&':
         return '&amp;';
       case '\"':
         return '&quot;';
+      default:
+        return match;
     }
   });
 };
@@ -38,13 +43,16 @@ HTMLSerializer.prototype.attr = function(attr) {
     return '';
   }
   if (attr.value) {
+    if (attr.name === 'href' || attr.name === 'src') {
+      return ' ' + attr.name + '="' + attr.value + '"';
+    }
     return ' ' + attr.name + '="' + this.escapeAttrValue(attr.value) + '"';
   }
   return ' ' + attr.name;
 };
 
-HTMLSerializer.prototype.escapeText = function(textNodeValue) {
-  return textNodeValue.replace(/[&<>]/g, function(match) {
+HTMLSerializer.prototype.escapeText = function(textNodeValue, escapeAll) {
+  return textNodeValue.replace(escapeAll ? REG_ESCAPE_ALL : REG_ESCAPE_PRESERVE_ENTITIES, function(match) {
     switch(match) {
       case '&':
         return '&amp;';
@@ -52,6 +60,8 @@ HTMLSerializer.prototype.escapeText = function(textNodeValue) {
         return '&lt;';
       case '>':
         return '&gt;';
+      default:
+        return match;
     }
   });
 };
@@ -97,7 +107,7 @@ HTMLSerializer.prototype.serialize = function(node) {
   	  next = next.nextSibling;
   	}
   } else if(node.nodeType === 1 && node.textContent){
-  	buffer += node.textContent;
+    buffer += this.escapeText(node.textContent, true);
   }
 
   if (node.nodeType === 1 && !this.isVoid(node)) {

--- a/package.json
+++ b/package.json
@@ -33,17 +33,19 @@
     "npmIgnore": [
       "testee"
     ],
-    "transpiler": "babel"
+    "transpiler": "babel",
+    "npmAlgorithm": "flat"
   },
   "devDependencies": {
-    "steal": "^0.11.4",
-    "steal-qunit": "^0.1.0",
-    "steal-tools": "^0.11.2",
+    "steal": "^0.16.33",
+    "steal-qunit": "^0.1.1",
+    "steal-tools": "^0.16.6",
     "testee": "^0.2.0",
-    "jquery": "^2.2.0"
+    "jquery": "^2.2.0",
+    "simple-html-tokenizer": "^0.2.1"
   },
   "dependencies": {
-    "micro-location": "^0.1.4",
-    "simple-html-tokenizer": "^0.2.1"
+    "he": "^1.1.0",
+    "micro-location": "^0.1.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     },
     "npmIgnore": [
       "testee"
-    ],
-    "transpiler": "babel"
+    ]
   },
   "devDependencies": {
     "steal": "^1.0.0-rc.0",

--- a/test/parser-test.js
+++ b/test/parser-test.js
@@ -97,19 +97,18 @@ QUnit.test('void tags', function (assert) {
 
 QUnit.test('simple charater encode', function(assert) {
 
-  var fragment = this.parser.parse('hello > world &amp; goodbye');
+  var fragment = this.parser.parse('hello > world &amp; &nbsp;&nbsp;goodbye');
   assert.ok(fragment);
 
   var node = fragment.firstChild;
   assert.ok(node);
   assert.equal(node.nodeType, 3);
-  assert.equal(node.nodeValue, 'hello &#x3E; world &#x26; goodbye');
+  assert.equal(node.nodeValue, 'hello &#x3E; world &#x26; &#xA0;&#xA0;goodbye');
 });
 
 QUnit.test('node child charater encode', function(assert) {
   var fragment = this.parser.parse('<div>Foo & Bar &amp; Baz &lt; Buz &gt; Biz</div>');
   assert.ok(fragment);
-  console.log(fragment);
   var node = fragment.firstChild;
   assert.ok(node);
   assert.equal(node.nodeType, 1);
@@ -124,9 +123,8 @@ QUnit.test('node child charater encode', function(assert) {
 
 QUnit.test('node attribute charater encode', function(assert) {
 
-  var fragment = this.parser.parse('<div title="foo & bar &amp; baz < buz > biz"></div>');
+  var fragment = this.parser.parse('<div title="&nbsp;foo & bar &amp; baz < buz > biz"></div>');
   assert.ok(fragment);
-  console.log(fragment);
 
   var node = fragment.firstChild;
   assert.ok(node);
@@ -137,5 +135,5 @@ QUnit.test('node attribute charater encode', function(assert) {
   assert.ok(attibutes.length);
   var title = attibutes[0];
   assert.equal(title.name, 'title');
-  assert.equal(title.value, 'foo &#x26; bar &#x26; baz &#x3C; buz &#x3E; biz');
+  assert.equal(title.value, '&#xA0;foo &#x26; bar &#x26; baz &#x3C; buz &#x3E; biz');
 });

--- a/test/serializer-test.js
+++ b/test/serializer-test.js
@@ -9,15 +9,29 @@ QUnit.module('Serializer', {
   }
 });
 
+QUnit.test('simple text', function(assert) {
+  var actual = this.serializer.serialize(fragment(
+    text('hello > world &amp; &nbsp;&nbsp; & goodbye')
+  ));
+  assert.equal(actual, 'hello &gt; world &amp; &nbsp;&nbsp; &amp; goodbye');
+});
+
 QUnit.test('serializes correctly', function (assert) {
   var actual = this.serializer.serialize(fragment(
-    element('div', { id:'foo' },
+    element('div', { id:'foo', title: '&amp;&"'},
       element('b', {},
-        text('Foo & Bar')
+        text('Foo & Bar &amp; Baz < Buz > Biz ©')
       )
     )
   ));
-  assert.equal(actual, '<div id="foo"><b>Foo &amp; Bar</b></div>');
+  assert.equal(actual, '<div id="foo" title="&amp;&amp;&quot;"><b>Foo &amp; Bar &amp; Baz &lt; Buz &gt; Biz ©</b></div>');
+});
+
+QUnit.test('serializes image correctly', function (assert) {
+  var actual = this.serializer.serialize(fragment(
+    element('img', { src:'https://foo.com/foobar.jpg?foo=bar&bar=foo'})
+  ));
+  assert.equal(actual, '<img src="https://foo.com/foobar.jpg?foo=bar&bar=foo">');
 });
 
 QUnit.test('serializes textContent', function(assert) {

--- a/test/test.js
+++ b/test/test.js
@@ -2,3 +2,4 @@ import './element-test';
 import './serializer-test';
 import './element-sp-test';
 import './element-event-test';
+import './parser-test';


### PR DESCRIPTION
this should fix the issue that html entities were not encoded.
https://github.com/canjs/can-simple-dom/issues/19
https://github.com/donejs/done-ssr/issues/181

i added 'he' as @m-mujica mention.

if no one has objection @matthewp @justinbmeyer @DesignByOnyx  i will merge that PR

encode html entities for char-nodes and title and alt attributes
(cherry picked from commit 7397af2)
