### PR TITLE
Two-way bind input value, checked properties

### DIFF
--- a/lib/simple-dom/document.js
+++ b/lib/simple-dom/document.js
@@ -4,8 +4,8 @@ import Text from './document/text';
 import Comment from './document/comment';
 import DocumentFragment from './document/document-fragment';
 import AnchorElement from './document/anchor-element';
-
-
+import InputElement from './document/input-element';
+import SelectElement from './document/select-element';
 
 function Document() {
   this.nodeConstructor(9, '#document', null, this);
@@ -21,7 +21,7 @@ function Document() {
 
       var body = Element.prototype.getElementsByTagName.call(frag,"body")[0];
       var head = Element.prototype.getElementsByTagName.call(frag,"head")[0];
-      
+
       if(!body && !head) {
         document.body.appendChild(frag);
       } else {
@@ -45,7 +45,9 @@ Document.prototype.constructor = Document;
 Document.prototype.nodeConstructor = Node;
 
 const specialElements = {
-  "a": AnchorElement
+  "a": AnchorElement,
+  "input": InputElement,
+  "select": SelectElement
 };
 
 Document.prototype.createElement = function(tagName) {

--- a/lib/simple-dom/document/element.js
+++ b/lib/simple-dom/document/element.js
@@ -73,6 +73,19 @@ Element.prototype._setAttribute = function(_name, value) {
   }
 };
 
+Element.prototype.hasAttribute = function(_name) {
+	var attributes = this.attributes;
+	var name = _name.toLowerCase();
+	var attr;
+	for(var i = 0, len = attributes.length; i < len; i++) {
+		attr = attributes[i];
+		if(attr.name === name) {
+			return true;
+		}
+	}
+	return false;
+};
+
 Element.prototype.removeAttribute = function(name) {
   var attributes = this.attributes;
   for (var i=0, l=attributes.length; i<l; i++) {
@@ -183,7 +196,6 @@ if(Object.defineProperty) {
 			this.parentNode.replaceChild(this.ownerDocument.__parser.parse(html), this);
 		}
 	});
-
 }
 
 

--- a/lib/simple-dom/document/input-element.js
+++ b/lib/simple-dom/document/input-element.js
@@ -1,0 +1,28 @@
+import Element from './element';
+import { propToAttr } from './utils.js';
+
+function InputElement(tagName, ownerDocument) {
+	this.elementConstructor(tagName, ownerDocument);
+}
+
+InputElement.prototype = Object.create(Element.prototype);
+InputElement.prototype.constructor = InputElement;
+InputElement.prototype.elementConstructor = Element;
+
+propToAttr(InputElement, "type");
+propToAttr(InputElement, "value");
+
+Object.defineProperty(InputElement.prototype, "checked", {
+	get: function(){
+		return this.hasAttribute("checked");
+	},
+	set: function(value){
+		if(value) {
+			this.setAttribute("checked", "");
+		} else {
+			this.removeAttribute("checked");
+		}
+	}
+});
+
+export default InputElement;

--- a/lib/simple-dom/document/select-element.js
+++ b/lib/simple-dom/document/select-element.js
@@ -1,0 +1,14 @@
+import Element from './element';
+import { propToAttr } from './utils';
+
+function SelectElement(tagName, ownerDocument) {
+	this.elementConstructor(tagName, ownerDocument);
+}
+
+SelectElement.prototype = Object.create(Element.prototype);
+SelectElement.prototype.constructor = SelectElement;
+SelectElement.prototype.elementConstructor = Element;
+
+propToAttr(SelectElement, "value");
+
+export default SelectElement;

--- a/lib/simple-dom/document/utils.js
+++ b/lib/simple-dom/document/utils.js
@@ -1,0 +1,12 @@
+
+
+export function propToAttr(Element, name){
+	Object.defineProperty(Element.prototype, name, {
+		get: function(){
+			return this.getAttribute(name);
+		},
+		set: function(val){
+			this.setAttribute(name, val);
+		}
+	});
+};

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -203,3 +203,52 @@ QUnit.test("removeChild should return the removed node", function(assert) {
 
 	assert.strictEqual(removedNode, child, "removeChild should return the removed node");
 });
+
+QUnit.test("Input's type property is two-way bound to the attribute", function(assert){
+	var document = new Document();
+	var input = document.createElement("input");
+	input.setAttribute("type", "text");
+
+	assert.equal(input.type, "text");
+
+	input.type = "radio";
+	assert.equal(input.type, "radio");
+	assert.equal(input.getAttribute("type"), "radio");
+});
+
+QUnit.test("Input's value property is two-way bound to the attribute", function(assert){
+	var document = new Document();
+	var input = document.createElement("input");
+	input.setAttribute("value", "foo");
+
+	assert.equal(input.value, "foo");
+
+	input.value = "bar";
+	assert.equal(input.value, "bar");
+	assert.equal(input.getAttribute("value"), "bar");
+});
+
+QUnit.test("Input's checked value is two-way bound", function(assert){
+	var document = new Document();
+	var input = document.createElement("input");
+
+	input.setAttribute("checked", "");
+	assert.ok(input.checked);
+
+	input.checked = false;
+	assert.equal(input.hasAttribute("checked"), false);
+	assert.equal(input.checked, false);
+});
+
+QUnit.test("Select's value attribute is two-way bound", function(assert){
+	var document = new Document();
+	var select = document.createElement("select");
+
+	select.setAttribute("value", "foo");
+
+	assert.equal(select.value, "foo");
+
+	select.value = "bar";
+	assert.equal(select.value, "bar");
+	assert.equal(select.getAttribute("value"), "bar");
+});


### PR DESCRIPTION
This makes an `input` and `select`'s checked, value, and type properties
to be two-way bound where it makes sense.
