### PR TITLE
use steal 0.16 to avoid syntax error for the amd built

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,9 @@
     "transpiler": "babel"
   },
   "devDependencies": {
-    "steal": "^0.11.4",
+    "steal": "^0.16.0",
     "steal-qunit": "^0.1.0",
-    "steal-tools": "^0.11.2",
+    "steal-tools": "^0.16.0",
     "testee": "^0.2.0",
     "jquery": "^2.2.0"
   },


### PR DESCRIPTION
@nriesco and @phillipskevin found some syntax error in can-simple-dom
https://gitter.im/donejs/donejs?at=57ebe6d3ca69aeb745ba33be

@matthewp we should use steal 0.16.X for building can-simple-dom.
