### PR TITLE
Make CSStyleDeclaration enum/conf

### DIFF
--- a/lib/simple-dom/document/element.js
+++ b/lib/simple-dom/document/element.js
@@ -1,5 +1,5 @@
 import Node from './node';
-
+import CSSStyleDeclaration from './style';
 
 let attrSpecial = {
   "class": function(element, value){
@@ -12,7 +12,7 @@ function Element(tagName, ownerDocument) {
   tagName = tagName.toUpperCase();
 
   this.nodeConstructor(1, tagName, null, ownerDocument);
-  this.style = new Style(this);
+  this.style = new CSSStyleDeclaration(this);
   this.attributes = [];
   this.tagName = tagName;
 }
@@ -157,12 +157,6 @@ if(Object.defineProperty) {
 		set: function(val){
 			this._setAttribute("class", val);
 			this._className = val;
-		}
-	});
-	Object.defineProperty(Style.prototype,"cssText",{
-		get: function() { return this.__node.getAttribute("style") || ""; },
-		set: function(val){
-			this.__node._setAttribute("style", val);
 		}
 	});
 

--- a/lib/simple-dom/document/style.js
+++ b/lib/simple-dom/document/style.js
@@ -1,0 +1,16 @@
+function CSSStyleDeclaration(node){
+	this.__node = node;
+}
+
+Object.defineProperty(CSSStyleDeclaration.prototype,"cssText", {
+	enumerable: true,
+	configurable: true,
+	get: function(){
+		return this.__node.getAttribute("style") || "";
+	},
+	set: function(val){
+		this.__node._setAttribute("style", val);
+	}
+});
+
+export default CSSStyleDeclaration;

--- a/lib/test/style-test.js
+++ b/lib/test/style-test.js
@@ -1,0 +1,16 @@
+import QUnit from 'steal-qunit';
+import CSSStyleDeclaration from 'can-simple-dom/simple-dom/document/style';
+
+QUnit.module("can-simple-dom - CSStyleDeclaration");
+
+QUnit.test("cssText is enumerable", function(){
+	var proto = CSSStyleDeclaration.prototype;
+	var descriptor = Object.getOwnPropertyDescriptor(proto, "cssText");
+	QUnit.equal(descriptor.enumerable, true, "it is enumerable");
+});
+
+QUnit.test("cssText is configurable", function(){
+	var proto = CSSStyleDeclaration.prototype;
+	var descriptor = Object.getOwnPropertyDescriptor(proto, "cssText");
+	QUnit.equal(descriptor.configurable, true, "it is configurable");
+});

--- a/lib/test/test.js
+++ b/lib/test/test.js
@@ -3,3 +3,4 @@ import './serializer-test';
 import './element-sp-test';
 import './element-event-test';
 import './parser-test';
+import './style-test';


### PR DESCRIPTION
This fixes the CSSSTyleDeclaration type to be enumerable and
configurable. This makes it possible for outside code to override this
property and matches browser implementations.

Closes #56