### PR TITLE
Fix property descriptors to be enum/config

### DIFF
--- a/lib/simple-dom/document/element.js
+++ b/lib/simple-dom/document/element.js
@@ -153,6 +153,8 @@ function Style(node){
 
 if(Object.defineProperty) {
 	Object.defineProperty(Element.prototype, "className", {
+		configurable: true,
+		enumerable: true,
 		get: function() { return this._className || ""; },
 		set: function(val){
 			this._setAttribute("class", val);
@@ -161,6 +163,8 @@ if(Object.defineProperty) {
 	});
 
 	Object.defineProperty(Element.prototype, "innerHTML", {
+		configurable: true,
+		enumerable: true,
 		get: function() {
 			var html = "";
 			var cur = this.firstChild;

--- a/lib/simple-dom/document/input-element.js
+++ b/lib/simple-dom/document/input-element.js
@@ -13,6 +13,8 @@ propToAttr(InputElement, "type");
 propToAttr(InputElement, "value");
 
 Object.defineProperty(InputElement.prototype, "checked", {
+	configurable: true,
+	enumerable: true,
 	get: function(){
 		return this.hasAttribute("checked");
 	},

--- a/lib/simple-dom/document/option-element.js
+++ b/lib/simple-dom/document/option-element.js
@@ -12,6 +12,8 @@ OptionElement.prototype.elementConstructor = Element;
 propToAttr(OptionElement, "value");
 
 Object.defineProperty(OptionElement.prototype, "selected", {
+	enumerable: true,
+	configurable: true,
 	get: function(){
 		var val = this.value || "";
 		var parent = this.parentNode;

--- a/lib/simple-dom/document/utils.js
+++ b/lib/simple-dom/document/utils.js
@@ -2,6 +2,8 @@
 
 export function propToAttr(Element, name){
 	Object.defineProperty(Element.prototype, name, {
+		configurable: true,
+		enumerable: true,
 		get: function(){
 			return this.getAttribute(name);
 		},

--- a/lib/test/element-test.js
+++ b/lib/test/element-test.js
@@ -283,3 +283,30 @@ QUnit.test("Option's selected value is tied to parent select's value", function(
 	option.selected = true;
 	assert.equal(select.value, "bar");
 });
+
+QUnit.test("option's selected property is configurable and enumerable", function(assert){
+    var document = new Document();
+    var option = document.createElement("option");
+    var proto = option.__proto__;
+    var desc = Object.getOwnPropertyDescriptor(proto, "selected");
+    assert.equal(desc.enumerable, true, "selected is enumerable");
+    assert.equal(desc.configurable, true, "selected is configurable");
+});
+
+QUnit.test("The className property is configurable and enumerable", function(assert){
+    var document = new Document();
+    var option = document.createElement("some-el");
+    var proto = option.__proto__;
+    var desc = Object.getOwnPropertyDescriptor(proto, "className");
+    assert.equal(desc.enumerable, true, "selected is enumerable");
+    assert.equal(desc.configurable, true, "selected is configurable");
+});
+
+QUnit.test("The innerHTML property is configurable and enumerable", function(assert){
+    var document = new Document();
+    var option = document.createElement("some-el");
+    var proto = option.__proto__;
+    var desc = Object.getOwnPropertyDescriptor(proto, "innerHTML");
+    assert.equal(desc.enumerable, true, "selected is enumerable");
+    assert.equal(desc.configurable, true, "selected is configurable");
+});


### PR DESCRIPTION
Most (and probably all) property descriptors in HTML are both enumerable and configurable. This allows 3rd party libraries to wrap these properties for their own purposes (canjs/dom-patch uses this to know when a property changes, for example).

Closes #58