### PR TITLE
Remove TextNode encoding

### DIFF
--- a/lib/simple-dom/html-parser.js
+++ b/lib/simple-dom/html-parser.js
@@ -41,8 +41,7 @@ HTMLParser.prototype.popElement = function(token) {
 };
 
 HTMLParser.prototype.appendText = function(token) {
-  var content = he.encode(token.chars);
-  var text = this.document.createTextNode(content);
+  var text = this.document.createTextNode(token.chars);
   this.appendChild(text);
 };
 

--- a/lib/test/parser-test.js
+++ b/lib/test/parser-test.js
@@ -95,32 +95,6 @@ QUnit.test('void tags', function (assert) {
   assert.equal(node.nextSibling, null);
 });
 
-QUnit.test('simple charater encode', function(assert) {
-
-  var fragment = this.parser.parse('hello > world &amp; &nbsp;&nbsp;goodbye');
-  assert.ok(fragment);
-
-  var node = fragment.firstChild;
-  assert.ok(node);
-  assert.equal(node.nodeType, 3);
-  assert.equal(node.nodeValue, 'hello &#x3E; world &#x26; &#xA0;&#xA0;goodbye');
-});
-
-QUnit.test('node child charater encode', function(assert) {
-  var fragment = this.parser.parse('<div>Foo & Bar &amp; Baz &lt; Buz &gt; Biz</div>');
-  assert.ok(fragment);
-  var node = fragment.firstChild;
-  assert.ok(node);
-  assert.equal(node.nodeType, 1);
-  assert.equal(node.nodeName, 'DIV');
-
-  node = node.firstChild;
-  assert.ok(node);
-  assert.equal(node.nodeType, 3);
-  assert.equal(node.nodeValue, 'Foo &#x26; Bar &#x26; Baz &#x3C; Buz &#x3E; Biz');
-
-});
-
 QUnit.test('node attribute charater encode', function(assert) {
 
   var fragment = this.parser.parse('<div title="&nbsp;foo & bar &amp; baz < buz > biz"></div>');


### PR DESCRIPTION
The browser doesn't encode TextNodes. This leads to unexpected output.

```js
var div = document.createElement('div');
div.innerHTML = 'hello > world &   goodbye';

div.textContent; // -> 'hello > world &   goodbye'
```