### PR TITLE
Add getters for documentElement, body, and head

### DIFF
--- a/lib/simple-dom/document.js
+++ b/lib/simple-dom/document.js
@@ -10,10 +10,10 @@ import SelectElement from './document/select-element';
 
 function Document() {
   this.nodeConstructor(9, '#document', null, this);
-  this.documentElement = new Element('html', this);
-  this.body = new Element('body', this);
-  this.documentElement.appendChild(this.body);
-  this.appendChild(this.documentElement);
+  var documentElement = new Element('html', this);
+  var body = new Element('body', this);
+  documentElement.appendChild(body);
+  this.appendChild(documentElement);
   var self = this;
   this.implementation = {
     createHTMLDocument: function(content){
@@ -108,6 +108,34 @@ if(Object.defineProperty) {
       return first;
     }
   });
+
+	Object.defineProperty(Document.prototype, "documentElement", {
+		get: function(){
+			return this.firstChild;
+		}
+	});
+
+	function firstOfKind(root, nodeName) {
+		if(root == null) return null;
+		var node = root.firstChild;
+		while(node) {
+			if(node.nodeName === nodeName) {
+				return node;
+			}
+			node = node.nextSibling;
+		}
+		return null;
+	}
+
+	["head", "body"].forEach(function(localName){
+		var nodeName = localName.toUpperCase();
+		Object.defineProperty(Document.prototype, localName, {
+			get: function() {
+				return firstOfKind(this.documentElement, nodeName);
+			},
+			set: Function.prototype
+		});
+	});
 }
 
 export default Document;

--- a/lib/simple-dom/document.js
+++ b/lib/simple-dom/document.js
@@ -8,6 +8,8 @@ import InputElement from './document/input-element';
 import OptionElement from './document/option-element';
 import SelectElement from './document/select-element';
 
+var noop = Function.prototype;
+
 function Document() {
   this.nodeConstructor(9, '#document', null, this);
   var documentElement = new Element('html', this);
@@ -112,7 +114,10 @@ if(Object.defineProperty) {
 	Object.defineProperty(Document.prototype, "documentElement", {
 		get: function(){
 			return this.firstChild;
-		}
+		},
+		// Noop the setter so if any code tries to set the documentElement
+		// It does not throw.
+		set: noop
 	});
 
 	function firstOfKind(root, nodeName) {
@@ -133,7 +138,7 @@ if(Object.defineProperty) {
 			get: function() {
 				return firstOfKind(this.documentElement, nodeName);
 			},
-			set: Function.prototype
+			set: noop
 		});
 	});
 }

--- a/lib/test/element-test.js
+++ b/lib/test/element-test.js
@@ -158,6 +158,22 @@ QUnit.test("replaceChild works", function(assert){
 	assert.equal(parent.firstChild.nodeName, 'SPAN', 'child is now the span');
 });
 
+QUnit.test("Replacing the document's firstChild updates documentElement", function(assert){
+	var document = new Document();
+	var first = document.documentElement;
+
+	var html = document.createElement("html");
+	var head = document.createElement("head");
+	var body = document.createElement("body");
+	html.appendChild(head);
+	html.appendChild(body);
+	document.replaceChild(html, document.documentElement);
+
+	assert.equal(document.documentElement, html, "documentElement is updated");
+	assert.equal(document.body, body, "document.body is updated");
+	assert.equal(document.head, head, "document.head is updated");
+});
+
 QUnit.test("setAttribute('class', value) updates the className", function(assert){
 	var document = new Document();
 	var el = document.createElement("div");


### PR DESCRIPTION
This adds getters for document.body, document.head, and
document.documentElement as defined by the spec:
https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2

Fixes #65