### PR TITLE
Change DOM operations to internal calls

### DIFF
--- a/lib/simple-dom/document/node.js
+++ b/lib/simple-dom/document/node.js
@@ -25,7 +25,7 @@ Node.prototype.cloneNode = function(deep) {
 
     while (nextChild) {
       nextChild = child.nextSibling;
-      node.appendChild(child.cloneNode(true));
+      nodeAppendChild.call(node, child.cloneNode(true));
       child = nextChild;
     }
   }
@@ -33,13 +33,15 @@ Node.prototype.cloneNode = function(deep) {
   return node;
 };
 
-Node.prototype.appendChild = function(node) {
+var nodeAppendChild = Node.prototype.appendChild = function(node) {
   if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
     insertFragment(node, this, this.lastChild, null);
     return node;
   }
 
-  if (node.parentNode) { node.parentNode.removeChild(node); }
+  if (node.parentNode) {
+    nodeRemoveChild.call(node.parentNode, node);
+  }
 
   node.parentNode = this;
   var refNode = this.lastChild;
@@ -87,7 +89,7 @@ function insertFragment(fragment, newParent, before, after) {
 
 var nodeInsertBefore = Node.prototype.insertBefore = function(node, refNode) {
   if (refNode == null) {
-    return this.appendChild(node);
+    return nodeAppendChild.call(this, node);
   }
 
   if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
@@ -96,7 +98,7 @@ var nodeInsertBefore = Node.prototype.insertBefore = function(node, refNode) {
   }
 
   if (node.parentNode) {
-    node.parentNode.removeChild(node);
+    nodeRemoveChild.call(node.parentNode, node);
   }
 
   node.parentNode = this;


### PR DESCRIPTION
replaceChild, insertBefore, etc. make some calls to other DOM
operations. This means that any code that is wrapping the DOM operations
will see these internal calls. To fix this I changed it so that the DOM
operations directly call the internal functions.

Closes #67