### PR TITLE
Ensure the ownerDocument points to the correct document

### DIFF
--- a/lib/simple-dom/document/node.js
+++ b/lib/simple-dom/document/node.js
@@ -53,6 +53,7 @@ var nodeAppendChild = Node.prototype.appendChild = function(node) {
     refNode.nextSibling = node;
     this.lastChild = node;
   }
+  ensureOwnerDocument(this, node);
   return node;
 };
 
@@ -72,6 +73,7 @@ function insertFragment(fragment, newParent, before, after) {
 
   while (node) {
     node.parentNode = newParent;
+    ensureOwnerDocument(newParent, node);
     lastChild = node;
     node = node.nextSibling;
   }
@@ -85,6 +87,20 @@ function insertFragment(fragment, newParent, before, after) {
 
   fragment.firstChild = null;
   fragment.lastChild = null;
+}
+
+function ensureOwnerDocument(parent, child){
+  var ownerDocument = parent.nodeType === 9 ? parent : parent.ownerDocument;
+  if(parent.ownerDocument !== child.ownerDocument) {
+    var node = child;
+    while(node) {
+      node.ownerDocument = ownerDocument;
+      if(node.firstChild) {
+        ensureOwnerDocument(node, node.firstChild);
+      }
+      node = node.nextSibling;
+    }
+  }
 }
 
 var nodeInsertBefore = Node.prototype.insertBefore = function(node, refNode) {
@@ -115,6 +131,7 @@ var nodeInsertBefore = Node.prototype.insertBefore = function(node, refNode) {
   if (this.firstChild === refNode) {
     this.firstChild = node;
   }
+  ensureOwnerDocument(this, node);
   return node;
 };
 

--- a/lib/test/element-test.js
+++ b/lib/test/element-test.js
@@ -329,3 +329,42 @@ QUnit.test("The innerHTML property is configurable and enumerable", function(ass
     assert.equal(desc.enumerable, true, "selected is enumerable");
     assert.equal(desc.configurable, true, "selected is configurable");
 });
+
+QUnit.test("Elements created in one document but inserted into another have their ownerDocument updated", function(assert){
+	var doc1 = new Document();
+	var doc2 = new Document();
+
+	var div = doc1.createElement("div");
+	var span = doc1.createElement("span");
+	div.appendChild(span);
+	doc2.body.appendChild(div);
+
+	assert.equal(div.ownerDocument, doc2, "The ownerDocument was updated");
+	assert.equal(span.ownerDocument, doc2, "ownerDocument on a child was updated too");
+});
+
+QUnit.test("Elements created in one document but inserted into another have their ownerDocument updated (documentElement)", function(assert){
+	var doc1 = new Document();
+	var doc2 = new Document();
+
+	var html = doc1.createElement("html");
+	doc2.replaceChild(html, doc2.documentElement);
+
+	assert.equal(html.ownerDocument, doc2, "The ownerDocument was updated");
+});
+
+QUnit.test("Elements created in one document but inserted into another have their ownerDocument updated (DocumentFragment)", function(assert){
+	var doc1 = new Document();
+	var doc2 = new Document();
+
+	var div = doc1.createElement("div");
+	var span = doc1.createElement("span");
+	div.appendChild(span);
+	var frag = doc1.createDocumentFragment();
+	frag.appendChild(div);
+	doc2.body.appendChild(frag);
+
+	assert.equal(div.ownerDocument, doc2, "The ownerDocument was updated");
+	assert.equal(span.ownerDocument, doc2, "ownerDocument on a child was updated too");
+});
+


### PR DESCRIPTION
When doing DOM operations that add Nodes to parent nodes, make sure the
child nodes (and its children)' `ownerDocument` points to the parent's
ownerDocument. Fixes #70