### PR TITLE
Add no-op CSSStyleDeclaration.getPropertyValue method

### DIFF
--- a/lib/simple-dom/document/style.js
+++ b/lib/simple-dom/document/style.js
@@ -2,6 +2,8 @@ function CSSStyleDeclaration(node){
 	this.__node = node;
 }
 
+CSSStyleDeclaration.prototype.getPropertyValue = function () {};
+
 Object.defineProperty(CSSStyleDeclaration.prototype,"cssText", {
 	enumerable: true,
 	configurable: true,

--- a/lib/test/style-test.js
+++ b/lib/test/style-test.js
@@ -14,3 +14,8 @@ QUnit.test("cssText is configurable", function(){
 	var descriptor = Object.getOwnPropertyDescriptor(proto, "cssText");
 	QUnit.equal(descriptor.configurable, true, "it is configurable");
 });
+
+QUnit.test('getPropertyValue must be a function', function () {
+	var proto = CSSStyleDeclaration.prototype;
+	QUnit.equal(typeof proto.getPropertyValue, 'function', 'it is a function');
+});


### PR DESCRIPTION
Closes #25 

jQuery 1.9.1 and 2.x need `getPropertyValue()` so that calls such as `$('#foo').css('font-size')` do not blow up. The [method usage is limited](https://github.com/jquery/jquery/blob/2d4f53416e5f74fa98e0c1d66b6f3c285a12f0ce/test/data/jquery-1.9.1.js#L7135) so we don't need more than a no-op function.