### PR TITLE
Implement textContent as Element getter/setter

### DIFF
--- a/lib/simple-dom/document/element.js
+++ b/lib/simple-dom/document/element.js
@@ -1,4 +1,4 @@
-import Node from './node';
+import {nodeRemoveChild, default as Node} from './node';
 import CSSStyleDeclaration from './style';
 
 let attrSpecial = {
@@ -192,6 +192,20 @@ if(Object.defineProperty) {
 		},
 		set: function(html) {
 			this.parentNode.replaceChild(this.ownerDocument.__parser.parse(html), this);
+		}
+	});
+
+	Object.defineProperty(Element.prototype, "textContent", {
+		get: function(){
+			var fc = this.firstChild;
+			return (fc && fc.nodeValue) || "";
+		},
+		set: function(val){
+			while(this.firstChild) {
+				nodeRemoveChild.call(this, this.firstChild);
+			}
+			var tn = this.ownerDocument.createTextNode(val);
+			this.appendChild(tn);
 		}
 	});
 }

--- a/lib/simple-dom/document/node.js
+++ b/lib/simple-dom/document/node.js
@@ -192,3 +192,4 @@ ChildNodes.prototype.item = function(index) {
 };
 
 export default Node;
+export {nodeRemoveChild};

--- a/lib/test/element-test.js
+++ b/lib/test/element-test.js
@@ -368,3 +368,32 @@ QUnit.test("Elements created in one document but inserted into another have thei
 	assert.equal(span.ownerDocument, doc2, "ownerDocument on a child was updated too");
 });
 
+QUnit.test("Setting an element's textContent inserts TextNode", function(assert){
+	var document = new Document();
+	var el = document.createElement("div");
+	el.textContent = "foo";
+
+	var tn = el.childNodes.item(0);
+	assert.equal(tn.nodeType, 3, "It is a TextNode");
+	assert.equal(tn.nodeValue, "foo", "With the text");
+	assert.equal(el.textContent, "foo", "Getter works");
+});
+
+QUnit.test("Setting textContent when there is already a child", function(assert){
+	var document = new Document();
+	var el = document.createElement("div");
+
+	// Add a child
+	el.appendChild(document.createElement("span"));
+
+	assert.equal(el.childNodes.item(0).nodeName, "SPAN", "starts as a span");
+
+	el.textContent = "hello world";
+
+	var tn = el.childNodes.item(0);
+	assert.equal(tn.nodeType, 3, "It is a TextNode");
+	assert.equal(tn.nodeValue, "hello world", "With the text");
+	assert.equal(el.textContent, "hello world", "Getter works");
+
+	assert.equal(el.childNodes.item(1), null, "span is gone");
+});


### PR DESCRIPTION
This implements textContent as a getter/setter. This is needed in order
for it to generate a mutation event in dom-patch.

Closes #32