### PR TITLE
Reflect anchor's href property

### DIFF
--- a/lib/document/anchor-element.js
+++ b/lib/document/anchor-element.js
@@ -7,6 +7,13 @@ const Location = microLocation.Location || microLocation;
 function AnchorElement(tagName, ownerDocument) {
   this.elementConstructor(tagName, ownerDocument);
 
+  Object.defineProperty(this, "_href", {
+	  enumerable: false,
+	  configurable: true,
+	  writable: true,
+	  value: ""
+  });
+
   extend(this, Location.parse(''));
 }
 
@@ -20,5 +27,17 @@ AnchorElement.prototype.setAttribute = function(_name, value){
     extend(this, Location.parse(value));
   }
 };
+
+Object.defineProperty(AnchorElement.prototype, "href", {
+	get: function() {
+		return this._href;
+	},
+	set: function(val) {
+		if(val !== this._href) {
+			this._href = val;
+			this.setAttribute("href", val);
+		}
+	}
+});
 
 module.exports = AnchorElement;

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -141,6 +141,14 @@ QUnit.test("anchor element is created successfully - micro-location works (see #
   }
 });
 
+QUnit.test("anchor elements href is reflected on attributes", function(assert) {
+	assert.expect(1);
+	var document = new Document();
+	var el = document.createElement("a");
+	el.href = "foo.com";
+	assert.equal(el.getAttribute("href"), "foo.com");
+});
+
 QUnit.test("style.cssText is two way bound to the style attribute (#13)", function(assert){
   var document = new Document();
   var el = document.createElement('div');


### PR DESCRIPTION
This change makes it so that an anchor's `href` property reflects back
onto attributes. This is consistent with how browser doms work.

For https://github.com/donejs/donejs/issues/1154