### PR TITLE
Add Compare document position

### DIFF
--- a/lib/document/compare-document-position.js
+++ b/lib/document/compare-document-position.js
@@ -1,0 +1,78 @@
+var getChildNodes = require("can-child-nodes");
+
+module.exports = function(Node) {
+
+  Node.DOCUMENT_POSITION_DISCONNECTED = 1;
+  Node.DOCUMENT_POSITION_PRECEDING = 2;
+  Node.DOCUMENT_POSITION_FOLLOWING = 4;
+  Node.DOCUMENT_POSITION_CONTAINS = 8;
+  Node.DOCUMENT_POSITION_CONTAINED_BY = 16;
+  Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32;
+
+  Node.prototype.compareDocumentPosition = function(other) {
+    function getFirstNodeByOrder(nodes, nodeOne, nodeTwo) {
+      return nodes.reduce(function(result, node) {
+        if (result !== false) {
+          return result;
+        } else if (node === nodeOne) {
+          return nodeOne;
+        } else if (node === nodeTwo) {
+          return nodeTwo;
+        } else if (node.childNodes) {
+          return getFirstNodeByOrder(getChildNodes(node), nodeOne, nodeTwo);
+        } else {
+          return false;
+        }
+      }, false);
+    }
+
+    function isAncestor(source, target) {
+      while (target.parentNode) {
+        target = target.parentNode;
+        if (target === source) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    function eitherContains(left, right) {
+      return isAncestor(left, right) ?
+        Node.DOCUMENT_POSITION_CONTAINED_BY + Node.DOCUMENT_POSITION_FOLLOWING :
+        isAncestor(right, left) ?
+        Node.DOCUMENT_POSITION_CONTAINS + Node.DOCUMENT_POSITION_PRECEDING :
+        false;
+    }
+
+    function getRootNode(node) {
+      while (node.parentNode) {
+        node = node.parentNode;
+      }
+      return node;
+    }
+
+    if (this === other) {
+      return 0;
+    }
+
+    var referenceRoot = getRootNode(this);
+    var otherRoot = getRootNode(other);
+
+    if (referenceRoot !== otherRoot) {
+      return Node.DOCUMENT_POSITION_DISCONNECTED;
+    }
+
+    var result = eitherContains(this, other);
+    if (result) {
+      return result;
+    }
+
+    var first = getFirstNodeByOrder([referenceRoot], this, other);
+    return first === this ?
+      Node.DOCUMENT_POSITION_FOLLOWING :
+      first === other ?
+      Node.DOCUMENT_POSITION_PRECEDING :
+      Node.DOCUMENT_POSITION_DISCONNECTED;
+  };
+
+};

--- a/lib/document/node.js
+++ b/lib/document/node.js
@@ -1,3 +1,5 @@
+var makeCompareDocumentPosition = require("./compare-document-position");
+
 function Node(nodeType, nodeName, nodeValue, ownerDocument) {
   this.nodeType = nodeType;
   this.nodeName = nodeName;
@@ -174,6 +176,8 @@ Node.prototype.contains = function(child){
 
 Node.prototype.addEventListener = function(){};
 Node.prototype.removeEventListener = function(){};
+
+makeCompareDocumentPosition(Node);
 
 Node.ELEMENT_NODE = 1;
 Node.ATTRIBUTE_NODE = 2;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "testee": "^0.3.1"
   },
   "dependencies": {
+    "can-child-nodes": "^1.2.0",
     "he": "^1.1.0",
     "micro-location": "^0.1.4",
     "simple-html-tokenizer": "^0.2.1"

--- a/test/element-test.js
+++ b/test/element-test.js
@@ -444,3 +444,13 @@ QUnit.test("Setting textContent when there is already a child", function(assert)
 
 	assert.equal(el.childNodes.item(1), null, "span is gone");
 });
+
+QUnit.test("compareDocumentPosition", function(assert){
+	var document = new Document();
+	var parent = document.createElement("div");
+	var child = document.createElement("span");
+
+	parent.appendChild(child);
+	
+	assert.equal( parent.compareDocumentPosition(child), 20, "contains");
+});


### PR DESCRIPTION
This is needed for CanJS 6.  Obviously, this could use more tests in this repo, but it is extensively tested downstream by CanJS.