### PR TITLE
svg-use-fix: use getAttributeNS() & setAttributeNS()

### DIFF
--- a/lib/document/element.js
+++ b/lib/document/element.js
@@ -47,6 +47,19 @@ Element.prototype.getAttribute = function(_name) {
   return null;
 };
 
+Element.prototype.getAttributeNS = function(namespaceURI, _name) {
+  var attributes = this.attributes;
+  var name = _name.toLowerCase();
+  var attr;
+  for (var i=0, l=attributes.length; i<l; i++) {
+    attr = attributes[i];
+    if (attr.name === name && attr.namespaceURI === namespaceURI) {
+      return attr.value;
+    }
+  }
+  return null;
+};
+
 Element.prototype.setAttribute = function(){
 	return this._setAttribute.apply(this, arguments);
 };


### PR DESCRIPTION
SVG namespace fix when svg-attribute contains stache-expression