### PR TITLE
shim HTMLElement & customElements

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,5 @@
 {
-  "predef": ["QUnit"],
+  "predef": ["QUnit", "module", "require", "exports"],
   "camelcase": true,
   "curly": true,
   "eqeqeq": true,

--- a/can-simple-dom.js
+++ b/can-simple-dom.js
@@ -8,6 +8,8 @@ exports = module.exports = SimpleDOM.Document;
 
 exports.Node = SimpleDOM.Node;
 exports.Element = SimpleDOM.Element;
+exports.HTMLElement = SimpleDOM.HTMLElement;
+exports.customElements = SimpleDOM.customElements;
 exports.Document = SimpleDOM.Document;
 exports.Event = SimpleDOM.Event;
 exports.HTMLParser = SimpleDOM.HTMLParser;

--- a/lib/document/custom-elements.js
+++ b/lib/document/custom-elements.js
@@ -1,4 +1,4 @@
-var _registry = [];
+var _registry = {};
 
 var customElements = {
 	define: function define(tagName, constructor){

--- a/lib/document/custom-elements.js
+++ b/lib/document/custom-elements.js
@@ -1,0 +1,12 @@
+var _registry = [];
+
+var customElements = {
+	define: function define(tagName, constructor){
+		_registry[tagName] = constructor;
+	},
+	get: function get(tagName) {
+		return _registry[tagName];
+	}
+};
+
+module.exports = customElements;

--- a/lib/document/html-element.js
+++ b/lib/document/html-element.js
@@ -1,0 +1,8 @@
+var Element = require('./element');
+
+function HTMLElement() {}
+
+HTMLElement.prototype = Object.create(Element.prototype);
+HTMLElement.prototype.constructor = HTMLElement;
+
+module.exports = HTMLElement;

--- a/lib/dom.js
+++ b/lib/dom.js
@@ -1,5 +1,7 @@
 var Node = require('./document/node').Node;
 var Element = require('./document/element');
+var HTMLElement = require('./document/html-element');
+var customElements = require('./document/custom-elements');
 var Document = require('./document');
 var Event = require('./event');
 var HTMLParser = require('./html-parser');
@@ -15,6 +17,8 @@ function createDocument (serializer, parser){
 
 exports.Node = Node;
 exports.Element = Element;
+exports.HTMLElement = HTMLElement;
+exports.customElements = customElements;
 exports.Document = Document;
 exports.Event = Event;
 exports.HTMLParser = HTMLParser;

--- a/test/custom-elements-test.js
+++ b/test/custom-elements-test.js
@@ -1,0 +1,34 @@
+var customElements = require('../lib/document/custom-elements');
+var HTMLElement = require('../lib/document/html-element');
+//var Document = require('../lib/document');
+var unit = require('steal-qunit');
+
+unit.module('can-simple-dom - Custom Elements');
+
+unit.test('customElements & HTMLElement have basic expected shape', function(assert) {
+	assert.ok(customElements && customElements.define && customElements.get);
+	assert.ok(typeof HTMLElement === 'function');
+});
+
+// TODO: next task is getting something like this to pass
+// unit.test('customElement lifecycle basics work', function(assert) {
+// 	var document = new Document();
+// 	var doneConstruct = assert.async();
+// 	var doneCallback = assert.async();
+// 	assert.expect(2);
+//
+// 	var TestElement = function() {
+// 		assert.ok('Called element constructor at creation');
+// 		doneCallback();
+// 	};
+// 	TestElement.prototype = Object.create(document.HTMLElement.prototype);
+// 	TestElement.prototype.constructor = TestElement;
+// 	TestElement.connectedCallback = function () {
+// 		assert.ok('Called element constructor at creation');
+// 		doneConstruct();
+// 	};
+//
+// 	document.customElements.define('test-el', TestElement);
+// 	var el = document.createElement('test-el');
+// 	document.body.appendChild(el);
+// });


### PR DESCRIPTION
Added basic shim for HTMLElement & customElements.

With the changes here and in my can-vdom PR (canjs/can-vdom#70) the DoneJS chat demo now renders without error.