### PR TITLE
Node should report it contains itself

### DIFF
--- a/lib/document/node.js
+++ b/lib/document/node.js
@@ -164,7 +164,6 @@ Node.prototype.replaceChild = function(newChild, oldChild){
 };
 
 Node.prototype.contains = function(child){
-	child = child.parentNode;
 	while(child) {
 		if(child === this) {
 			return true;

--- a/test/document-test.js
+++ b/test/document-test.js
@@ -12,3 +12,10 @@ unit.test('Document should contain appended Elements', function (assert) {
 	document.body.removeChild(element);
 	assert.notOk(document.contains(element), 'document should not contain element');
 });
+
+unit.test('Allow a Node to report that it contains itself', function(assert) {
+	var element = document.createElement('div');
+	document.body.appendChild(element);
+	assert.ok(element.contains(element), 'An element contains itself');
+	document.body.removeChild(element);
+});


### PR DESCRIPTION
Closes #98

Allow a node.contains(node) to return true.